### PR TITLE
Add an opt-in option to unmarshal

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -26,5 +26,5 @@
   ],
   "test-depends": [
   ],
-  "version": "0.11"
+  "version": "0.10"
 }

--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,8 @@
   ],
   "depends": [
     "JSON::Fast",
-    "JSON::Name"
+    "JSON::Name:ver<0.0.6+>",
+    "JSON::OptIn"
   ],
   "description": "Turn JSON into objects",
   "license": "Artistic-2.0",
@@ -25,5 +26,5 @@
   ],
   "test-depends": [
   ],
-  "version": "0.10"
+  "version": "0.11"
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ SYNOPSIS
     say $object.string; # -> "string"
     say $object.int;    # -> 42
 
+
+Or explictly opt-in the attributes for deserialization:
+
+    use JSON::Unmarshal;
+    use JSON::OptIn;
+
+    class SomeClass {
+        has Str $.string  = "original";
+        has Int $.int     is json;
+    }
+
+    my $json = '{ "string" : "string", "int" : 42 }';
+
+    my SomeClass $object = unmarshal($json, SomeClass, :opt-in);
+
+    say $object.string; # -> "original"
+    say $object.int;    # -> 42
+
+
 It is also possible to use a trait to control how the value is unmarshalled:
 
     use JSON::Unmarshal
@@ -45,9 +64,9 @@ The trait has two variants, one which takes a Routine as above, the other a Str 
 DESCRIPTION
 ===========
 
-
-
 This provides a single exported subroutine to create an object from a JSON representation of an object.
+
+It only initialises the "public" attributes (that is those with accessors created by declaring them with the '.' twigil.) Attributes without acccessors are ignored. By default *all* the public attributes present in the JSON will be initialised, which may not be ideal if you are accepting JSON from a source outside of your control (such as some http API,) and/or there are attributes which are lazily built from other other data:  if the `:opt-in` adverb is passed to `unmarshal` only those attributes marked explicitly with the `is json` trait (from `JSON::OptIn`,) or have the traits `json-name` ( from `JSON::Name`,) or `unmarshalled-by` will be initialised from the JSON.
 
 It only initialises the "public" attributes (that is those with accessors created by declaring them with the '.' twigil. Attributes without acccessors are ignored.
 

--- a/t/opt-in.t
+++ b/t/opt-in.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env raku
+
+use Test;
+use JSON::Unmarshal;
+use JSON::OptIn;
+use JSON::Name;
+
+class OptInClass {
+
+    has Str $.not_opted_in = "original";
+    has Str $.opted_in     is json;
+}
+
+my $json = '{ "not_opted_in" : "not original", "opted_in" : "something" }';
+
+my $obj;
+
+lives-ok { $obj = unmarshal($json, OptInClass, :opt-in) }, 'unmarshal with opt-in';
+
+is $obj.not_opted_in, 'original', "attribute not marked explicitly not populated from JSON";
+is $obj.opted_in, 'something', "attribute marked is set";
+
+done-testing;
+# vim: ft=raku


### PR DESCRIPTION
In some applications it might not be ideal to initialise all the
attributes that are present in the JSON (either for security or other
application reasons,) so this adds an `:opt-in` adverb to `unmarshal`
such that, if applied, only those attributes that have been explicitly
allowed (by appliction of a trait,) will be initialised.