### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ NAME
 
 JSON::Unmarshal
 
-Make JSON from an Object (the opposite of JSON::Marshal)
+Make an Object from JSON (the opposite of JSON::Marshal)
 
 SYNOPSIS
 ========


### PR DESCRIPTION
Correct description to:

"JSON::Unmarshal --Make an Object from JSON (the opposite of JSON::Unmarshal)"

After this commit the description will read as above, complementing @jonathanstowe 's description of his `JSON::Marshal` module (below):

"JSON::Marshal -- Make JSON from an Object (the opposite of JSON::Unmarshal)"