### PR TITLE
Add some safety

### DIFF
--- a/lib/JSON/Unmarshal.rakumod
+++ b/lib/JSON/Unmarshal.rakumod
@@ -88,7 +88,7 @@ Please see the LICENCE file in the distribution
 
 =end pod
 
-our class X::CannotUnmarshal is Exception is export {
+our class X::CannotUnmarshal is Exception {
     has Attribute:D $.attribute is required;
     has Any:D $.json is required;
     has Mu:U $.type is required;
@@ -98,6 +98,20 @@ our class X::CannotUnmarshal is Exception is export {
         "Cannot unmarshal {$.json.raku} into type '{$.type.^name}' for attribute {$.attribute.name} of '{$.target.^name}'"
         ~ ($.why andthen ": $_" orelse "")
     }
+}
+
+our class X::UnusedKeys is Exception {
+    has Set:D $.unused-keys is required;
+    method message {
+        my $sfx = $!unused-keys.elems > 1 ?? "s" !! "";
+        "No attribute$sfx found for JSON key$sfx " ~ $!unused-keys.keys.sort.map("'" ~ * ~ "'").join(", ")
+    }
+}
+
+enum ErrorMode <EM_IGNORE EM_WARN EM_THROW>;
+my class UnmarshallParams {
+    has Bool $.opt-in;
+    has ErrorMode $.error-mode;
 }
 
 role CustomUnmarshaller does JSON::OptIn::OptedInAttribute {
@@ -150,18 +164,18 @@ multi sub panic($json, Mu \type, Str $why?) {
         :target($*JSON-UNMARSHAL-TYPE) ).throw
 }
 
-multi _unmarshal(Any:U, Mu $type, Bool :$opt-in ) {
+multi _unmarshal(Any:U, Mu $type) {
     $type;
 }
 
-multi _unmarshal(Any:D $json, Int, Bool :$opt-in) {
+multi _unmarshal(Any:D $json, Int) {
     if $json ~~ Int {
         return Int($json)
     }
     panic($json, Int)
 }
 
-multi _unmarshal(Any:D $json, Rat, Bool :$opt-in) {
+multi _unmarshal(Any:D $json, Rat) {
    CATCH {
       default {
          panic($json, Rat, $_);
@@ -170,14 +184,14 @@ multi _unmarshal(Any:D $json, Rat, Bool :$opt-in) {
    return Rat($json);
 }
 
-multi _unmarshal(Any:D $json, Numeric, Bool :$opt-in) {
+multi _unmarshal(Any:D $json, Numeric) {
     if $json ~~ Numeric {
         return Num($json)
     }
     panic($json, Numeric)
 }
 
-multi _unmarshal($json, Str, Bool :$opt-in) {
+multi _unmarshal($json, Str) {
     if $json ~~ Stringy {
         return Str($json)
     }
@@ -186,7 +200,7 @@ multi _unmarshal($json, Str, Bool :$opt-in) {
     }
 }
 
-multi _unmarshal(Any:D $json, Bool, Bool :$opt-in) {
+multi _unmarshal(Any:D $json, Bool) {
    CATCH {
       default {
          panic($json, Bool, $_);
@@ -195,8 +209,10 @@ multi _unmarshal(Any:D $json, Bool, Bool :$opt-in) {
    return Bool($json);
 }
 
-multi _unmarshal(%json, Mu $obj is raw, Bool :$opt-in) {
+multi _unmarshal(%json, Mu $obj is raw) {
     my %args;
+    my $params = $*JSON-UNMARSHALL-PARAMS;
+    my SetHash $used-json-keys .= new;
     my \type = $obj.HOW.archetypes.nominalizable ?? $obj.^nominalize !! $obj.WHAT;
     my %local-attrs =  type.^attributes(:local).map({ $_.name => $_.package });
     for type.^attributes -> $attr {
@@ -204,7 +220,7 @@ multi _unmarshal(%json, Mu $obj is raw, Bool :$opt-in) {
         if %local-attrs{$attr.name}:exists && !(%local-attrs{$attr.name} === $attr.package ) {
             next;
         }
-        if $opt-in && $attr !~~ JSON::OptIn::OptedInAttribute {
+        if $params.opt-in && $attr !~~ JSON::OptIn::OptedInAttribute {
             next;
         }
         my $attr-name = $attr.name.substr(2);
@@ -216,6 +232,7 @@ multi _unmarshal(%json, Mu $obj is raw, Bool :$opt-in) {
         }
         if %json{$json-name}:exists {
             my Mu $attr-type := $attr.type;
+            $used-json-keys.set($json-name);
             %args{$attr-name} := do if $attr ~~ CustomUnmarshaller {
                 $attr.unmarshal(%json{$json-name}, $attr-type)
             }
@@ -227,71 +244,99 @@ multi _unmarshal(%json, Mu $obj is raw, Bool :$opt-in) {
                 %json{$json-name}
             }
             else {
-                _unmarshal(%json{$json-name}, $attr-type, :$opt-in)
+                _unmarshal(%json{$json-name}, $attr-type)
             }
+        }
+    }
+    if ((my $err-mode = $params.error-mode) != EM_IGNORE)
+        && (my $unused-keys = (%json.keys.Set (-) $used-json-keys))
+    {
+        my $ex = X::UnusedKeys.new: :$unused-keys;
+        if $err-mode == EM_WARN {
+           warn($ex.message)
+        }
+        else {
+           $ex.throw
         }
     }
     type.new(|%args)
 }
 
-multi _unmarshal($json, @x, Bool :$opt-in) {
+multi _unmarshal($json, @x) {
     my @ret := Array[@x.of].new;
     for $json.list -> $value {
        my $type = @x.of =:= Any ?? $value.WHAT !! @x.of;
-       @ret.append(_unmarshal($value, $type, :$opt-in));
+       @ret.append(_unmarshal($value, $type));
     }
     return @ret;
 }
 
-multi _unmarshal(%json, %x, Bool :$opt-in) {
+multi _unmarshal(%json, %x) {
    my %ret := Hash[%x.of].new;
    for %json.kv -> $key, $value {
       my $type = %x.of =:= Any ?? $value.WHAT !! %x.of;
-      %ret{$key} = _unmarshal($value, $type, :$opt-in);
+      %ret{$key} = _unmarshal($value, $type);
    }
    return %ret;
 }
 
-multi _unmarshal(Any:D $json, Mu, Bool :$opt-in) {
+multi _unmarshal(Any:D $json, Mu) {
     return $json
+}
+
+my sub _unmarshall-context(\obj, % (Bool :$opt-in, Bool :$warn, Bool :die(:$throw), *%extra), &code) is raw {
+    if %extra {
+        with "Unsupported arguments: " ~ %extra.keys.sort.map("'" ~ * ~ "'").join(", ") {
+            $throw ?? die $_ !! warn $_
+        }
+    }
+    my $*JSON-UNMARSHAL-TYPE := obj.WHAT;
+    my $*JSON-UNMARSHALL-PARAMS :=
+        UnmarshallParams.new: :$opt-in, error-mode => (($throw && EM_THROW) // ($warn && EM_WARN) // EM_IGNORE);
+    code()
 }
 
 proto unmarshal(Any:D, |) is export {*}
 
-multi unmarshal(Str:D $json, Positional $obj, Bool :$opt-in) {
-    my $*JSON-UNMARSHAL-TYPE := $obj.WHAT;
-    my Any \data = from-json($json);
-    if data ~~ Positional {
-        return @(_unmarshal($_, $obj.of, :$opt-in) for @(data));
-    } else {
-        fail "Unmarshaling to type $obj.^name() requires the json data to be a list of objects.";
+multi unmarshal(Str:D $json, Positional $obj, *%c) {
+    _unmarshall-context $obj, %c, {
+        my Any \data = from-json($json);
+        if data ~~ Positional {
+            return @(_unmarshal($_, $obj.of) for @(data));
+        } else {
+            fail "Unmarshaling to type $obj.^name() requires the json data to be a list of objects.";
+        }
     }
 }
 
-multi unmarshal(Str:D $json, Associative $obj, Bool :$opt-in) {
-    my $*JSON-UNMARSHAL-TYPE := $obj.WHAT;
-    my \data = from-json($json);
-    if data ~~ Associative {
-        return %(for data.kv -> $key, $value {
-            $key => _unmarshal($value, $obj.of, :$opt-in )
-        })
-    } else {
-        fail "Unmarshaling to type $obj.^name() requires the json data to be an object.";
-    };
+multi unmarshal(Str:D $json, Associative $obj, *%c) {
+    _unmarshall-context $obj, %c, {
+        my \data = from-json($json);
+        if data ~~ Associative {
+            return %(for data.kv -> $key, $value {
+                $key => _unmarshal($value, $obj.of)
+            })
+        } else {
+            fail "Unmarshaling to type $obj.^name() requires the json data to be an object.";
+        };
+    }
 }
 
-multi unmarshal(Str:D $json, $obj, Bool :$opt-in) {
-    my $*JSON-UNMARSHAL-TYPE := $obj.WHAT;
-    _unmarshal(from-json($json), $obj.WHAT, :$opt-in)
+multi unmarshal(Str:D $json, $obj, *%c) {
+    _unmarshall-context $obj, %c, {
+        _unmarshal(from-json($json), $obj.WHAT)
+    }
 }
 
-multi unmarshal(%json, $obj, Bool :$opt-in) {
-    my $*JSON-UNMARSHAL-TYPE := $obj.WHAT;
-    _unmarshal(%json, $obj.WHAT, :$opt-in)
+multi unmarshal(%json, $obj, *%c) {
+    _unmarshall-context $obj, %c, {
+        _unmarshal(%json, $obj.WHAT)
+    }
 }
 
-multi unmarshal(@json, $obj, Bool :$opt-in) {
-    my $*JSON-UNMARSHAL-TYPE := $obj.WHAT;
-    _unmarshal(@json, $obj.WHAT, :$opt-in)
+multi unmarshal(@json, $obj, *%c) {
+    _unmarshall-context $obj, %c, {
+        _unmarshal(@json, $obj.WHAT)
+    }
 }
 # vim: expandtab shiftwidth=4 ft=raku

--- a/lib/JSON/Unmarshal.rakumod
+++ b/lib/JSON/Unmarshal.rakumod
@@ -195,7 +195,7 @@ multi _unmarshal(Any:D $json, Bool, Bool :$opt-in) {
    return Bool($json);
 }
 
-multi _unmarshal(%json, Any $obj is raw, Bool :$opt-in) {
+multi _unmarshal(%json, Mu $obj is raw, Bool :$opt-in) {
     my %args;
     my \type = $obj.HOW.archetypes.nominalizable ?? $obj.^nominalize !! $obj.WHAT;
     my %local-attrs =  type.^attributes(:local).map({ $_.name => $_.package });

--- a/t/010-basic.rakutest
+++ b/t/010-basic.rakutest
@@ -89,5 +89,28 @@ is $p.hash<int>, 1;
 is $p.hash<bool>, True;
 is $p.hash<rat>, 42.3;
 
+subtest "unmarshall named arguments", {
+    plan 2;
+
+    {
+        my $warn-msg = "";
+        CONTROL {
+            when CX::Warn {
+                $warn-msg = .message;
+                .resume
+            }
+        }
+        unmarshal '{}', HashTest, :warn, :foo, :bar;
+
+        like 
+            $warn-msg, 
+            /"Unsupported arguments: 'bar', 'foo'"/, 
+            "unsupported named arguments result in a warning with :warn";
+    }
+
+    dies-ok { unmarshal '{}', HashTest, :die, :foo, :bar }, 
+            "it dies with unsupported named arguments and :die (or :throw)";
+}
+
 done-testing;
 # vim: expandtab shiftwidth=4 ft=raku

--- a/t/010-basic.rakutest
+++ b/t/010-basic.rakutest
@@ -1,6 +1,8 @@
 use Test;
 use JSON::Unmarshal;
 
+plan 25;
+
 class Dog {
     has Str $.name;
     has Str $.race;

--- a/t/020-any.rakutest
+++ b/t/020-any.rakutest
@@ -3,6 +3,8 @@ use v6;
 use Test;
 use JSON::Unmarshal;
 
+plan 16;
+
 class AnyAttributeClass {
     has $.any-attr;
 }

--- a/t/030-null.rakutest
+++ b/t/030-null.rakutest
@@ -5,6 +5,8 @@ use v6.*;
 use Test;
 use JSON::Unmarshal;
 
+plan 4;
+
 my Str $json = '{ "attr" : null }';
 
 my @tests = %( "class" => class  { has Int $.attr; }, description => "Int attribute" ),

--- a/t/050-json-name.rakutest
+++ b/t/050-json-name.rakutest
@@ -8,6 +8,8 @@ use Test;
 use JSON::Unmarshal;
 use JSON::Name;
 
+plan 2;
+
 class TestClass {
     has $.nice-name is rw is json-name('666.evil.name');
 }

--- a/t/070-parameterised.rakutest
+++ b/t/070-parameterised.rakutest
@@ -3,6 +3,8 @@
 use Test;
 use JSON::Unmarshal;
 
+plan 2;
+
 class C {
 	has Str %.bla{subset :: of Str where any("ble", "blob")}
 }; 

--- a/t/090-unused-keys.t
+++ b/t/090-unused-keys.t
@@ -1,0 +1,34 @@
+use Test;
+use JSON::Unmarshal;
+
+plan 2;
+
+class Foo {
+    has Int $.count;
+    has Bool $.check;
+}
+
+my $json = '{"count": 42, "check": true, "description": "about something", "name": "fubar" }';
+
+{
+    my $warn-msg;
+    CONTROL {
+        when CX::Warn {
+            $warn-msg = .message;
+            .resume
+        }
+    }
+    my Foo $foo = unmarshal $json, Foo, :warn;
+    my $msg = "a warning produced for unsued JSON keys with :warn";
+    with $warn-msg {
+        like $_, /"No attributes found " .* "'description', 'name'"/, $msg;
+    }
+    else {
+        flunk $msg;
+    }
+}
+throws-like 
+    { my Foo $foo = unmarshal $json, Foo, :throw; },
+    X::UnusedKeys,
+    :unused-keys(<description name>.Set),
+    "an exception is thrown for unsued JSON keys with :throw (or :die)";

--- a/t/opt-in.t
+++ b/t/opt-in.t
@@ -5,6 +5,8 @@ use JSON::Unmarshal;
 use JSON::OptIn;
 use JSON::Name;
 
+plan 3;
+
 class OptInClass {
 
     has Str $.not_opted_in = "original";


### PR DESCRIPTION
Make the module safer in some cases:

- Use more explicit parameter typing (this would also allow de-serializing non-`Any` classes)
- Add `:warn` and `:die` (or its alias `:throw`)  named parameters
- Add plans to tests

As to the new named parameters, they would result in reporting unsupported named arguments, like in `unmarshall ..., :warn, :no-idea`, and in reporting when a key in the source JSON doesn't have a mapping into class' attribute. Apparently, with `:warn` it would only produce a warning, whereas with `:die` it'd throw.