### PR TITLE
Revert breaking v6.e-ism "are(:Any)" to earlier junction and smartmatch.

### DIFF
--- a/t/080-trait.rakutest
+++ b/t/080-trait.rakutest
@@ -74,7 +74,7 @@ subtest "unmarshalled-by on a positional attribute" => {
         $obj = unmarshal $json, CustomArrayAttribute;
     }, "unmarshal with custom marshaller on positional attribute";
 
-    ok $obj.inners.are(CustomArrayAttribute::Inner), "and all the objects in the array are correct";
+    ok all($obj.inners) ~~ CustomArrayAttribute::Inner, "and all the objects in the array are correct";
     is-deeply $obj.inners.map( *.name), <one two three>, "and they have their names set correctly";
 }
 


### PR DESCRIPTION
This module breaks install of `App::Mi6` on earlier `v6.d` Rakudos.

This PR changes one line to its previous state as in `a0698ae2`.