### PR TITLE
Fixed failing test on Windows

### DIFF
--- a/t/080-trait.rakutest
+++ b/t/080-trait.rakutest
@@ -74,7 +74,16 @@ subtest "unmarshalled-by on a positional attribute" => {
         $obj = unmarshal $json, CustomArrayAttribute;
     }, "unmarshal with custom marshaller on positional attribute";
 
-    ok all($obj.inners) ~~ CustomArrayAttribute::Inner, "and all the objects in the array are correct";
+    # The code below is an expansion of the logic: all($obj.inners) ~~ CustomArrayAttribute::Inner
+    # It has been written out in full for compatibility across versions and OSes (looking at you windows).
+    {
+        my @checked = do for $obj.inners.kv -> $i, $inner {
+            ok $inner ~~ CustomArrayAttribute::Inner, "and all the objects in the array are correct (i=$i)";
+            $i
+        }
+        is @checked.tail, $obj.inners.end, "and all array objects were checked";
+    }
+    
     is-deeply $obj.inners.map( *.name), <one two three>, "and they have their names set correctly";
 }
 


### PR DESCRIPTION
unmarshalled-by on a positional attribute from 080-trait.rakutest was failing on windows after changes 0.16 -> 0.17

The error appears to be related to a potential inconsistency in the behaviour of a comparison:  `all($obj.inners) ~~ CustomArrayAttribute::Inner`

I've expanded the logic into a block of code which now passes while following the same algorithmic intent.